### PR TITLE
update mid calculation to avoid overflow

### DIFF
--- a/Basic techniques/Sorting/binary_search.cpp
+++ b/Basic techniques/Sorting/binary_search.cpp
@@ -9,7 +9,7 @@ void binary_search_conventional(int arr[], int size, int element){
     int start = 0, end = size - 1;
 
     while(start <= end){
-        int mid = (start + end) / 2;
+        int mid = start + (end - start) / 2;
 
         if(arr[mid] == element){
             cout << "Element found\n";


### PR DESCRIPTION
`int mid = (start + end) / 2 ` can cause overflow issues for a large sized array.